### PR TITLE
Not allowed implementation details in interfaces

### DIFF
--- a/array.h
+++ b/array.h
@@ -5,14 +5,9 @@
 
 class Array: public Object {
     public:
-    size_t arraySize;
-    Object** elements;
     
     /** Constructor for Array **/
-    Array() {
-        arraySize = 0;
-        elements = nullptr;
-    }
+    Array() {}
 
     // Appends e to end of array
     void push_back(Object* e) {}
@@ -59,9 +54,7 @@ class Array: public Object {
     }
 
     //destructing an Array
-    ~Array() {
-        delete[] elements;
-    } 
+    ~Array() {} 
 };
 
 class StrArray: public Object {

--- a/test-array.cpp
+++ b/test-array.cpp
@@ -54,7 +54,7 @@ void test_void_back() {
   String * s = new String("Hello");
   Array * l = new Array();
   l->push_back(s);
-  t_true(l->elements[0]->equals(s));
+  t_true(l->get(0)->equals(s));
   t_true(l->length() == 1);
   OK("test void_back");
 }
@@ -175,7 +175,7 @@ void test_arr_equals() {
     String * t = new String("World");
     Array * original = new Array();
     Array * copy = new Array();
-    t_true(original->elements == nullptr);
+    t_true(original->length() == 0);
     t_false(original->equals(copy));
     original->push_back(s);
     original->push_back(t);


### PR DESCRIPTION
Hi, 

I noticed you specified specific fields and implemented Constructor/Destructor for Array. From piazza, I do not think this is allowed. This pull request addresses that issue. It gets rid of the field declarations and constructor/destructor implementations. It also updates 2 tests that used field access and now they use the given interface to test what they seemed to be testing via field access.